### PR TITLE
rename and remove functions to be compatible with Bottender 0.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,18 +50,19 @@ bot.onEvent(
 ```js
 const { middleware } = require('bottender');
 const handovers = require('bottender-handovers');
-const { isRequestControlFrom, isRequestControlFromInbox } = require('bottender-handovers');
+const { isRequestThreadControlFrom } = require('bottender-handovers');
 
 // request from and pass to 3rd party CRM service
 const myCRMAppId = 123456;
 const handleHandovers = handovers({
-  shouldControlPass: isRequestControlFrom(myCRMAppId),
-  targetAppId: myCRMAppId
+  shouldControlPass: isRequestThreadControlFrom(myCRMAppId),
+  targetAppId: myCRMAppId,
 });
 
 // request from and pass to Facebook Page Inbox
 const handleHandovers = handovers({
-  shouldControlPass: isRequestControlFromInbox,
+  shouldControlPass: context =>
+    context.event.isRequestThreadControlFromPageInbox,
 });
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,9 @@ const warning = require('warning');
 const alwaysFalse = () => false;
 const noop = () => {};
 
-const isRequestControlFrom = appId => context =>
+const isRequestThreadControlFrom = appId => context =>
   context.event.isRequestThreadControl &&
   context.event.requestThreadControl.requested_owner_app_id === appId;
-
-const isRequestControlFromInbox = isRequestControlFrom(263902037430900);
 
 module.exports = ({
   shouldControlPass = alwaysFalse,
@@ -59,5 +57,4 @@ module.exports = ({
   }
 };
 
-module.exports.isRequestControlFrom = isRequestControlFrom;
-module.exports.isRequestControlFromInbox = isRequestControlFromInbox;
+module.exports.isRequestThreadControlFrom = isRequestThreadControlFrom;


### PR DESCRIPTION
We already have `context.event.isRequestThreadControlFromPageInbox` in Bottender 0.15, so `isRequestControlFromInbox` can be removed.